### PR TITLE
Bump Quarkus from 1.8.1 to 1.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@
 plugins {
     id 'java'
     id "com.diffplug.spotless" version "5.7.0"
-    id 'io.quarkus' version "1.8.1.Final"
+    id 'io.quarkus' version "1.9.1.Final"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 }
 
 ext {
-    quarkusVersion = '1.8.1.Final'
+    quarkusVersion = '1.9.1.Final'
 }
 
 repositories {


### PR DESCRIPTION
- Bump io.quarkus from 1.8.1.Final to 1.9.1.Final. Closes #15
- Bump quarkus-bom from 1.8.1.Final to 1.9.1.Final. Closes #16
