### PR TITLE
Bump Quarkus to 2.14.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up GraalVM
       uses: DeLaGuardo/setup-graalvm@5.0
       with:
-        graalvm: 22.0.0.2
+        graalvm: 22.3.0
         # optional, available: java8 and java11, defaults to java8
         java: java11
         # optional, available: amd64 and aarch64, defaults to amd64

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
 
 plugins {
     id 'java'
-    id "com.diffplug.spotless" version "6.6.1"
+    id "com.diffplug.spotless" version "6.12.0"
     id 'io.quarkus' version "2.14.2.Final"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,12 @@
 
 plugins {
     id 'java'
-    id "com.diffplug.spotless" version "6.12.0"
-    id 'io.quarkus' version "2.9.2.Final"
+    id "com.diffplug.spotless" version "6.6.1"
+    id 'io.quarkus' version "2.14.2.Final"
 }
 
 ext {
-    quarkusVersion = '2.9.2.Final'
+    bcprovVersion = '1.70'
 }
 
 repositories {
@@ -37,17 +37,18 @@ repositories {
 }
 
 dependencies {
+    implementation enforcedPlatform("io.quarkus.platform:quarkus-bom:2.14.2.Final")
     implementation 'io.quarkus:quarkus-smallrye-openapi'
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-resteasy-jsonb'
     implementation 'io.quarkus:quarkus-jsonb'
-    implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-scheduler'
     implementation 'io.quarkus:quarkus-container-image-jib'
     implementation 'io.quarkus:quarkus-kubernetes'
-    implementation enforcedPlatform("io.quarkus:quarkus-universe-bom:${quarkusVersion}")
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation "org.bouncycastle:bcprov-jdk15on:${bcprovVersion}"
+    implementation "org.bouncycastle:bcpkix-jdk15on:${bcprovVersion}"
 
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'


### PR DESCRIPTION
- Bump Quarkus dependencies to 2.14.2
- Fix build issues by bumping Spotless to 6.12.0
