### PR TITLE
Replace deprecated set-output command in GitHub Workflow Job Step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Retrieve branch or tag name
       id: refvar
-      run: echo "::set-output name=gitRefName::${GITHUB_REF#refs/*/}"
+      run: echo "gitRefName=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
     - name: Set up GraalVM
       uses: graalvm/setup-graalvm@v1


### PR DESCRIPTION
[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
